### PR TITLE
feat(experiment): add --dry-run flag for CPU-based smoke testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ Or run all phases sequentially:
 python experiments/run_all_phases.py --config configs/v2-focused.yaml
 ```
 
+### CPU Dry Run for Development
+
+Use the `--dry-run` flag to execute a quick, CPU-only smoke test that exercises the
+full Phase 1 pipeline with a tiny model and dataset:
+
+```bash
+python experiments/phase1_teacher_extraction.py --config configs/v2-focused.yaml --dry-run
+```
+
+This mode forces the model to `distilbert-base-uncased`, captures only a few concepts and
+prompts, and runs entirely on the CPU so it should finish within a few minutes. You can
+also invoke it via the multi-phase runner:
+
+```bash
+python experiments/run_all_phases.py --config configs/v2-focused.yaml --dry-run --skip-phase2 --skip-phase3 --skip-phase4
+```
+
 ## 📊 Expected Results
 
 ### Phase 1 Validation Targets

--- a/experiments/run_all_phases.py
+++ b/experiments/run_all_phases.py
@@ -65,6 +65,8 @@ def main():
     parser.add_argument("--skip-phase3", action="store_true", help="Skip Phase 3 (teacher H-SAE)")
     parser.add_argument("--skip-phase4", action="store_true", help="Skip Phase 4 (evaluation)")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Run Phase 1 with CPU-friendly settings for smoke testing")
     
     args = parser.parse_args()
     
@@ -120,6 +122,8 @@ def main():
             additional_args.extend(["--device", args.device])
         if args.debug:
             additional_args.append("--debug")
+        if args.dry_run and phase_script == "phase1_teacher_extraction.py":
+            additional_args.append("--dry-run")
         
         # Run phase
         phase_script_path = Path(__file__).parent / phase_script


### PR DESCRIPTION
## Summary
- add `--dry-run` option to Phase 1 experiment for a CPU smoke test with DistilBERT and a tiny concept set
- wire the flag through the multi-phase runner
- document how to run the CPU dry run for development

## Testing
- `python experiments/phase1_teacher_extraction.py --config configs/v2-focused.yaml --dry-run` *(fails: process killed after activation capture)*

------
https://chatgpt.com/codex/tasks/task_e_68a2414043a88321a124d251324cc883