### PR TITLE
Refine steering heuristics and validation utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,26 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from polytope_hsae.steering import ConceptSteering
+
+
+class DummyHSAE(torch.nn.Module):
+    def forward(self, x):
+        return x
+
+
+def test_steer_with_parent_vector_no_change():
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+    tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+    tokenizer.pad_token = tokenizer.eos_token
+    steering = ConceptSteering(model, tokenizer, DummyHSAE(), device="cpu")
+
+    parent_vector = torch.zeros(model.config.n_embd)
+    prompts = ["hello world"]
+
+    result = steering.steer_with_parent_vector(
+        prompts, parent_vector, magnitude=0.0, output_layer="lm_head"
+    )
+
+    assert torch.allclose(result["baseline_logits"], result["steered_logits"])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,49 @@
+import torch
+import pandas as pd
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from polytope_hsae.geometry import CausalGeometry
+from polytope_hsae.validation import GeometryValidator
+
+
+def test_hierarchical_orthogonality_returns_dataframe():
+    U = torch.eye(4)
+    geometry = CausalGeometry(U)
+    validator = GeometryValidator(geometry)
+
+    parent_vectors = {"p": torch.tensor([1.0, 0.0, 0.0, 0.0])}
+    child_deltas = {"p": {"c": torch.tensor([0.0, 1.0, 0.0, 0.0])}}
+
+    results = validator.test_hierarchical_orthogonality(parent_vectors, child_deltas)
+    assert isinstance(results["details"], pd.DataFrame)
+    assert set(results["details"].columns) == {
+        "parent_id",
+        "child_id",
+        "angle_deg",
+        "inner_product",
+    }
+    assert len(results["details"]) == 1
+
+
+def test_ratio_invariance_dataframe():
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+    tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+    tokenizer.pad_token = tokenizer.eos_token
+    U = torch.eye(model.config.n_embd)
+    geometry = CausalGeometry(U)
+    validator = GeometryValidator(geometry)
+
+    parent_vectors = {"p": torch.zeros(model.config.n_embd)}
+    test_contexts = {"p": ["hello world"]}
+    sibling_groups = {"p": ["hello", "world"]}
+
+    results = validator.test_ratio_invariance(
+        model,
+        tokenizer,
+        parent_vectors,
+        test_contexts,
+        sibling_groups,
+        alpha_values=[0.0],
+    )
+    assert isinstance(results["kl_divergences"], pd.DataFrame)


### PR DESCRIPTION
## Summary
- simplify concept steering by capturing hidden states once and optionally specifying the output layer
- expose detailed DataFrame outputs and progress bars in validation utilities with vectorized control experiments
- add unit tests covering steering and validation modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4af16e5fc83218bbd950ee03bb298