### PR TITLE
Refine activations, concepts, and estimators with async I/O and caching

### DIFF
--- a/polytope_hsae/prompt_templates.json
+++ b/polytope_hsae/prompt_templates.json
@@ -1,0 +1,48 @@
+{
+  "positive": [
+    "The {concept} is",
+    "A {concept} can",
+    "Every {concept} has",
+    "This {concept} will",
+    "The typical {concept} is",
+    "A good {concept} should",
+    "When you see a {concept}, you",
+    "The {concept} in the picture",
+    "My favorite {concept} is",
+    "The best {concept} I know",
+    "A {concept} always",
+    "The {concept} that I saw",
+    "This particular {concept} is",
+    "A {concept} like this",
+    "The {concept} here is",
+    "Such a {concept} would",
+    "A {concept} of this type",
+    "The {concept} shown is",
+    "This kind of {concept} is",
+    "A {concept} similar to this"
+  ],
+  "negative": [
+    "This is not a {concept}",
+    "Unlike a {concept}, this",
+    "This lacks the properties of a {concept}",
+    "This cannot be considered a {concept}",
+    "This is the opposite of a {concept}",
+    "This has nothing to do with {concept}",
+    "This is unrelated to any {concept}",
+    "This doesn't resemble a {concept}",
+    "This is clearly not a {concept}",
+    "This is different from a {concept}"
+  ],
+  "contextual": [
+    "In the story, the {concept} was",
+    "During the experiment, the {concept} showed",
+    "According to the expert, this {concept} is",
+    "In nature, a {concept} typically",
+    "The scientist studied the {concept} and found",
+    "The child pointed at the {concept} and said",
+    "In the museum, the {concept} was displayed",
+    "The book described the {concept} as",
+    "The documentary showed how the {concept} can",
+    "In this example, the {concept} demonstrates"
+  ]
+}

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,0 +1,55 @@
+import random
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from polytope_hsae.concepts import (
+    ConceptInfo,
+    ConceptHierarchy,
+    PromptGenerator,
+    ConceptSplitter,
+)
+
+
+def _dummy_concept(idx: int) -> ConceptInfo:
+    return ConceptInfo(
+        synset_id=f"c{idx}.n.01",
+        name=f"concept{idx}",
+        definition="",
+        examples=[],
+        pos="n",
+        lemmas=[f"concept{idx}"],
+    )
+
+
+def _dummy_hierarchy(idx: int) -> ConceptHierarchy:
+    parent = _dummy_concept(idx)
+    child = _dummy_concept(idx + 1000)
+    return ConceptHierarchy(parent=parent, children=[child], parent_prompts=[], child_prompts={})
+
+
+def test_prompt_generator_count():
+    random.seed(0)
+    generator = PromptGenerator(prompts_per_concept=10)
+    concept = _dummy_concept(0)
+    prompts = generator.generate_prompts_for_concept(concept)
+    assert len(prompts) == 10
+
+
+def test_concept_splitter_ratios():
+    random.seed(0)
+    hierarchies = [_dummy_hierarchy(i) for i in range(10)]
+    splitter = ConceptSplitter()
+    splits = splitter.split_hierarchies(hierarchies)
+    assert len(splits["train"]) == 7
+    assert len(splits["val"]) == 1
+    assert len(splits["test"]) == 2
+
+    prompts = [f"prompt {i}" for i in range(20)]
+    prompt_splits = splitter.split_prompts_within_concept(prompts)
+    assert len(prompt_splits["train"]) == 14
+    assert len(prompt_splits["val"]) == 3
+    assert len(prompt_splits["test"]) == 3
+
+

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,6 +1,14 @@
 import torch
+import sys
+import pathlib
 
-from polytope_hsae.estimators import LDAEstimator, validate_orthogonality
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from polytope_hsae.estimators import (
+    LDAEstimator,
+    validate_orthogonality,
+    OrthogonalityStats,
+)
 from polytope_hsae.geometry import CausalGeometry
 
 
@@ -30,8 +38,10 @@ def test_validate_orthogonality_detects_orthogonal_and_nonorthogonal():
     child_orth = {"p": {"c1": delta_ortho}}
     child_non = {"p": {"c1": delta_non}}
     stats_orth = validate_orthogonality(parent_vectors, child_orth, geom)
-    assert stats_orth["fraction_orthogonal_80deg"] == 1.0
-    assert abs(stats_orth["mean_inner_product"]) < 1e-5
+    assert isinstance(stats_orth, OrthogonalityStats)
+    assert stats_orth.fraction_orthogonal_80deg == 1.0
+    assert abs(stats_orth.mean_inner_product) < 1e-5
     stats_non = validate_orthogonality(parent_vectors, child_non, geom)
-    assert stats_non["fraction_orthogonal_80deg"] == 0.0
-    assert stats_non["mean_inner_product"] > 0.1
+    assert stats_non.fraction_orthogonal_80deg == 0.0
+    assert stats_non.mean_inner_product > 0.1
+

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,6 +1,10 @@
 import math
 
 import torch
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from polytope_hsae.geometry import CausalGeometry
 


### PR DESCRIPTION
## Summary
- Add optional dotted hook paths and antonym-based negative prompt generation with async HDF5 saves
- Extract prompt templates to JSON, add lazy NLTK setup, and cache WordNet lookups
- Document tensor↔numpy conversions, improve ridge mapping robustness, and return validated orthogonality stats
- Add unit tests for concept prompt generation and split ratios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4aee5027c83218a2cf3a6030cbeda