### PR TITLE
Add core geometry and model unit tests

### DIFF
--- a/polytope_hsae/geometry.py
+++ b/polytope_hsae/geometry.py
@@ -88,6 +88,8 @@ class CausalGeometry:
 
     def whiten(self, x: torch.Tensor) -> torch.Tensor:
         """Apply whitening transformation: x̃ = Wx."""
+        if x.ndim not in (1, 2):
+            raise ValueError("whiten expects a 1D or 2D tensor")
         W = self.W.to(
             x.device, dtype=x.dtype if x.dtype.is_floating_point else torch.float32
         )
@@ -95,8 +97,11 @@ class CausalGeometry:
 
     def unwhiten(self, x_whitened: torch.Tensor) -> torch.Tensor:
         """Apply inverse whitening transformation: x = x̃W^{-1} = x̃W^T."""
+        if x_whitened.ndim not in (1, 2):
+            raise ValueError("unwhiten expects a 1D or 2D tensor")
         W = self.W.to(
-            x_whitened.device, dtype=x_whitened.dtype if x_whitened.dtype.is_floating_point else torch.float32
+            x_whitened.device,
+            dtype=x_whitened.dtype if x_whitened.dtype.is_floating_point else torch.float32,
         )
         return x_whitened @ W
 
@@ -110,6 +115,10 @@ class CausalGeometry:
         Returns:
             Causal inner product
         """
+        if x.ndim not in (1, 2) or y.ndim not in (1, 2):
+            raise ValueError("inputs must be 1D or 2D tensors")
+        if x.ndim != y.ndim or x.shape[-1] != y.shape[-1]:
+            raise ValueError("inputs must have matching shapes")
         x_whitened = self.whiten(x)
         y_whitened = self.whiten(y)
         return torch.sum(x_whitened * y_whitened, dim=-1)

--- a/tests/test_estimators_lda.py
+++ b/tests/test_estimators_lda.py
@@ -1,0 +1,55 @@
+import torch
+import math
+from polytope_hsae.estimators import LDAEstimator
+from polytope_hsae.geometry import CausalGeometry
+
+
+def _to_original_space(geom: CausalGeometry, Z: torch.Tensor) -> torch.Tensor:
+    W_inv_T = torch.linalg.inv(geom.W.T)
+    return Z @ W_inv_T
+
+
+def test_lda_direction_points_between_class_means_and_is_unit_causal_norm():
+    torch.manual_seed(0)
+    d = 6
+    geom = CausalGeometry(torch.eye(d))
+
+    mu = torch.zeros(d)
+    mu[0] = 1.0
+    Z_pos = mu + 0.1 * torch.randn(200, d)
+    Z_neg = -mu + 0.1 * torch.randn(200, d)
+
+    X_pos = _to_original_space(geom, Z_pos)
+    X_neg = _to_original_space(geom, Z_neg)
+
+    lda = LDAEstimator(min_vocab_count=1)
+    w = lda.estimate_binary_direction(X_pos, X_neg, geom)
+
+    angle = geom.causal_angle(w, mu).item()
+    assert angle < math.radians(25.0)
+
+    norm = geom.causal_norm(w).item()
+    assert abs(norm - 1.0) < 1e-4
+
+
+def test_lda_handles_singular_within_class_scatter_and_bfloat16():
+    torch.manual_seed(0)
+    d = 5
+    geom = CausalGeometry(torch.eye(d))
+
+    Z_pos = torch.zeros(20, d)
+    Z_neg = torch.cat([torch.ones(10, d), torch.zeros(10, d)], dim=0)
+    X_pos = _to_original_space(geom, Z_pos)
+    X_neg = _to_original_space(geom, Z_neg)
+
+    lda = LDAEstimator(min_vocab_count=1)
+    w = lda.estimate_binary_direction(X_pos, X_neg, geom)
+    assert torch.isfinite(w).all()
+
+    w_bf16 = lda.estimate_binary_direction(
+        X_pos.to(torch.bfloat16), X_neg.to(torch.bfloat16), geom
+    )
+    assert torch.isfinite(w_bf16).all()
+    ang = geom.causal_angle(w, w_bf16).item()
+    assert ang < math.radians(5.0)
+

--- a/tests/test_geometry_core.py
+++ b/tests/test_geometry_core.py
@@ -1,0 +1,100 @@
+import math
+import torch
+import pytest
+
+from polytope_hsae.geometry import CausalGeometry
+
+DTYPES = [torch.float32, torch.bfloat16]
+
+
+def _spd_from_U(U: torch.Tensor, shrink: float = 1e-6):
+    X = U - U.mean(dim=0, keepdim=True)
+    Sigma = X.T @ X / max(1, X.shape[0] - 1)
+    d = Sigma.shape[0]
+    return Sigma + shrink * torch.eye(d)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_causal_ip_equals_Sigma_inv_dot(dtype):
+    torch.manual_seed(0)
+    V, d = 64, 8
+    U = torch.randn(V, d)
+    geom = CausalGeometry(U, shrinkage=1e-6)
+    x = torch.randn(d, dtype=dtype)
+    y = torch.randn(d, dtype=dtype)
+
+    ip_geom = geom.causal_inner_product(x, y).item()
+
+    Sigma = _spd_from_U(U).float()
+    Sigma_inv = torch.linalg.inv(Sigma)
+    ip_true = (x.float() @ Sigma_inv @ y.float()).item()
+
+    assert math.isfinite(ip_geom)
+    tol = 5e-2 if dtype == torch.bfloat16 else 1e-4
+    assert abs(ip_geom - ip_true) < tol
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_whiten_shapes_and_dtypes(dtype):
+    torch.manual_seed(0)
+    V, d = 50, 7
+    U = torch.randn(V, d)
+    geom = CausalGeometry(U)
+    x1 = torch.randn(d, dtype=dtype)
+    x2 = torch.randn(10, d, dtype=dtype)
+
+    w1 = geom.whiten(x1)
+    w2 = geom.whiten(x2)
+
+    assert w1.shape == x1.shape
+    assert w2.shape == x2.shape
+    assert torch.isfinite(w1).all() and torch.isfinite(w2).all()
+
+
+def test_causal_angle_properties_and_zero_vector():
+    torch.manual_seed(1)
+    V, d = 80, 6
+    U = torch.randn(V, d)
+    geom = CausalGeometry(U)
+
+    a = torch.randn(d)
+    assert torch.allclose(geom.causal_angle(a, 2.0 * a), torch.tensor(0.0), atol=1e-6)
+    assert torch.allclose(geom.causal_angle(a, -a), torch.tensor(math.pi), atol=1e-6)
+
+    aw = geom.whiten(a)
+    rand = torch.randn_like(aw)
+    bw = rand - (rand @ aw) / (aw @ aw + 1e-8) * aw
+    b = bw @ torch.linalg.pinv(geom.W)
+    angle = geom.causal_angle(a, b)
+    assert abs(angle.item() - math.pi / 2) < 1e-2
+
+    z = torch.zeros_like(a)
+    assert torch.isnan(geom.causal_angle(a, z))
+
+
+def test_project_and_orthogonalize_causal():
+    torch.manual_seed(2)
+    V, d = 60, 5
+    U = torch.randn(V, d)
+    geom = CausalGeometry(U)
+    v = torch.randn(d)
+    u = torch.randn(d)
+    u_perp = geom.orthogonalize_causal(u.unsqueeze(0), v.unsqueeze(0))[0]
+    ip = geom.causal_inner_product(v, u_perp).abs().item()
+    assert ip < 1e-6
+
+
+def test_bad_dimensional_inputs_raise():
+    torch.manual_seed(0)
+    V, d = 32, 4
+    U = torch.randn(V, d)
+    geom = CausalGeometry(U)
+    x = torch.randn(2, 3, d)
+    y = torch.randn(d)
+
+    with pytest.raises(Exception):
+        geom.whiten(x)
+
+    with pytest.raises(Exception):
+        geom.causal_inner_product(x, y)
+

--- a/tests/test_metrics_ev_ce.py
+++ b/tests/test_metrics_ev_ce.py
@@ -1,0 +1,56 @@
+import math
+import torch
+import pytest
+
+from polytope_hsae.metrics import (
+    compute_explained_variance,
+    compute_dual_explained_variance,
+    compute_cross_entropy_proxy,
+)
+from polytope_hsae.geometry import CausalGeometry
+
+DTYPES = [torch.float32, torch.bfloat16]
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_explained_variance_identity_and_zero(dtype):
+    torch.manual_seed(0)
+    x = torch.randn(128, 16).to(dtype)
+    ev_same = compute_explained_variance(x, x)
+    assert math.isclose(ev_same, 1.0, abs_tol=1e-5)
+
+    x_hat0 = torch.zeros_like(x)
+    ev_zero = compute_explained_variance(x, x_hat0)
+    assert math.isfinite(ev_zero)
+    assert ev_zero < 0.1
+
+
+def test_dual_explained_variance_matches_ev_in_identity_geometry():
+    torch.manual_seed(0)
+    n, d = 200, 8
+    x = torch.randn(n, d)
+    x_hat = x + 0.05 * torch.randn_like(x)
+
+    geom = CausalGeometry(torch.eye(d))
+
+    ev = compute_explained_variance(x, x_hat)
+    dual = compute_dual_explained_variance(x, x_hat, geom)
+    assert math.isclose(ev, dual["standard_ev"], abs_tol=5e-5)
+    assert math.isclose(ev, dual["causal_ev"], abs_tol=5e-5)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cross_entropy_proxy_shift_invariance_and_stability(dtype):
+    torch.manual_seed(0)
+    x = torch.randn(64, 11).to(dtype)
+    x_hat = x + 0.1 * torch.randn_like(x)
+    ce = compute_cross_entropy_proxy(x, x_hat)
+
+    c = 10.0 * torch.ones_like(x_hat)
+    ce_shift = compute_cross_entropy_proxy(x, x_hat + c)
+    assert math.isclose(ce, ce_shift, abs_tol=1e-6)
+
+    ce32 = compute_cross_entropy_proxy(x.float(), x_hat.float())
+    assert math.isfinite(ce) and math.isfinite(ce32)
+    assert abs(float(ce) - float(ce32)) < 3e-3
+

--- a/tests/test_models_biorth_penalties.py
+++ b/tests/test_models_biorth_penalties.py
@@ -1,0 +1,51 @@
+import torch
+from polytope_hsae.models import HierarchicalSAE, HSAEConfig
+
+
+def _make_orthonormal_rows(P, d):
+    W = torch.zeros(P, d)
+    for i in range(P):
+        W[i, i] = 1.0
+    return W
+
+
+def test_parent_child_biorth_offdiag_zero_when_E_equals_D():
+    d, P, C = 6, 4, 3
+    cfg = HSAEConfig(
+        input_dim=d, n_parents=P, topk_parent=1,
+        subspace_dim=d, n_children_per_parent=C, topk_child=1,
+        use_tied_decoders_parent=False, use_tied_decoders_child=False,
+    )
+    model = HierarchicalSAE(cfg)
+
+    with torch.no_grad():
+        E = _make_orthonormal_rows(P, d)
+        model.router.encoder.weight.copy_(E)
+        model.router.decoder.weight.copy_(E.t())
+
+        for sub in model.subspaces:
+            Ec = _make_orthonormal_rows(C, d)
+            sub.encoder.weight.copy_(Ec)
+            sub.decoder.weight.copy_(Ec.t())
+
+    parent_pen = model._biorth_penalty_parent_offdiag().item()
+    child_pen = sum(model._biorth_penalty_child_offdiag(i).item() for i in range(P))
+    assert parent_pen < 1e-8
+    assert child_pen < 1e-8
+
+
+def test_parent_biorth_offdiag_positive_when_rows_non_orthonormal():
+    d, P, C = 6, 4, 3
+    cfg = HSAEConfig(
+        input_dim=d, n_parents=P, topk_parent=1,
+        subspace_dim=d, n_children_per_parent=C, topk_child=1,
+    )
+    model = HierarchicalSAE(cfg)
+
+    with torch.no_grad():
+        model.router.encoder.weight.normal_()
+        model.router.decoder.weight.normal_()
+
+    pen = model._biorth_penalty_parent_offdiag().item()
+    assert pen > 1e-5
+

--- a/tests/test_models_hsae_core.py
+++ b/tests/test_models_hsae_core.py
@@ -1,0 +1,93 @@
+import torch
+import pytest
+from polytope_hsae.models import HierarchicalSAE, HSAEConfig
+from polytope_hsae.geometry import CausalGeometry
+
+
+def _tiny_hsae(d=8, P=3, C=2):
+    cfg = HSAEConfig(
+        input_dim=d,
+        n_parents=P,
+        topk_parent=1,
+        subspace_dim=d,
+        n_children_per_parent=C,
+        topk_child=1,
+        use_tied_decoders_parent=False,
+        use_tied_decoders_child=False,
+        tie_projectors=False,
+        normalize_decoder=True,
+    )
+    return HierarchicalSAE(cfg)
+
+
+def test_sample_codes_top1_training_and_eval():
+    torch.manual_seed(0)
+    model = _tiny_hsae()
+    logits = torch.randn(5, model.config.n_parents)
+
+    model.train()
+    codes_tr = model._sample_codes(logits, k=1)
+    assert torch.all((codes_tr.sum(dim=-1) - 1.0).abs() < 1e-6)
+
+    model.eval()
+    codes_ev = model._sample_codes(logits, k=1)
+    assert torch.all((codes_ev.sum(dim=-1) - 1.0).abs() < 1e-6)
+
+
+def test_update_router_temperature_endpoints():
+    model = _tiny_hsae()
+    start = model.config.router_temp_start
+    end = model.config.router_temp_end
+    model.update_router_temperature(step=0, total_steps=100)
+    assert torch.allclose(model.router_temperature, torch.tensor(start))
+    model.update_router_temperature(step=100, total_steps=100)
+    assert torch.allclose(model.router_temperature, torch.tensor(end))
+
+
+def test_normalize_decoder_weights_sets_unit_column_norms():
+    torch.manual_seed(0)
+    model = _tiny_hsae(d=10, P=4)
+    with torch.no_grad():
+        model.router.decoder.weight.copy_(torch.randn_like(model.router.decoder.weight))
+        for sub in model.subspaces:
+            sub.decoder.weight.copy_(torch.randn_like(sub.decoder.weight))
+    model.normalize_decoder_weights()
+
+    parent_norms = torch.norm(model.router.decoder.weight, dim=0)
+    assert torch.allclose(parent_norms, torch.ones_like(parent_norms), atol=1e-6)
+    for sub in model.subspaces:
+        cn = torch.norm(sub.decoder.weight, dim=0)
+        assert torch.allclose(cn, torch.ones_like(cn), atol=1e-6)
+
+
+def test_causal_orthogonality_penalty_zero_when_delta_orthogonal():
+    torch.manual_seed(0)
+    d, P, C = 8, 2, 1
+    model = _tiny_hsae(d, P, C)
+    geom = CausalGeometry(torch.eye(d))
+
+    with torch.no_grad():
+        model.router.decoder.weight.zero_()
+        model.router.decoder.weight[0, 0] = 1.0
+        model.router.decoder.weight[1, 1] = 1.0
+        for p, sub in enumerate(model.subspaces):
+            sub.up_projector.weight.copy_(torch.eye(d))
+            sub.decoder.weight.zero_()
+            delta = torch.zeros(d)
+            delta[(p + 2) % d] = 1.0
+            child_full = torch.zeros(d)
+            child_full[p] = 1.0
+            sub.decoder.weight[:, 0] = child_full
+
+    pen0 = model.compute_causal_orthogonality_penalty(geom).item()
+
+    with torch.no_grad():
+        for p, sub in enumerate(model.subspaces):
+            child_full = torch.zeros(d)
+            child_full[p] = 2.0
+            sub.decoder.weight[:, 0] = child_full
+    pen_parallel = model.compute_causal_orthogonality_penalty(geom).item()
+
+    assert pen0 <= 1e-8
+    assert pen_parallel > pen0 + 1e-4
+


### PR DESCRIPTION
## Summary
- add dimension validation to geometry operations
- ensure LDA estimator handles mixed dtypes safely
- introduce comprehensive tests for geometry, metrics, models, biorthogonality, and estimators

## Testing
- `pytest tests/test_geometry_core.py tests/test_metrics_ev_ce.py tests/test_models_hsae_core.py tests/test_models_biorth_penalties.py tests/test_estimators_lda.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a842df99b083219340f94284418e58