### PR TITLE
Optimize activation capture and training performance

### DIFF
--- a/experiments/phase2_baseline_hsae.py
+++ b/experiments/phase2_baseline_hsae.py
@@ -171,10 +171,14 @@ def _train_baseline_hsae_single_attempt(model, activations, config, exp_dir, att
     train_loader = create_data_loader(
         train_activations,
         batch_size=config["training"]["batch_size_acts"],
+        device=config["run"]["device"],
         shuffle=True,
     )
     val_loader = create_data_loader(
-        val_activations, batch_size=config["training"]["batch_size_acts"], shuffle=False
+        val_activations,
+        batch_size=config["training"]["batch_size_acts"],
+        device=config["run"]["device"],
+        shuffle=False,
     )
 
     # Initialize trainer

--- a/experiments/phase3_teacher_hsae.py
+++ b/experiments/phase3_teacher_hsae.py
@@ -241,10 +241,14 @@ def _train_teacher_hsae_single_attempt(model, activations, config, exp_dir, geom
     train_loader = create_data_loader(
         train_activations,
         batch_size=config["training"]["batch_size_acts"],
+        device=config["run"]["device"],
         shuffle=True,
     )
     val_loader = create_data_loader(
-        val_activations, batch_size=config["training"]["batch_size_acts"], shuffle=False
+        val_activations,
+        batch_size=config["training"]["batch_size_acts"],
+        device=config["run"]["device"],
+        shuffle=False,
     )
 
     # Initialize trainer


### PR DESCRIPTION
## Summary
- vectorize activation capture to avoid duplicate tokenization and enable bf16 device retention
- speed up training with TF32, fused AdamW and lazy H5 dataset, plus efficient DataLoader defaults
- batch causal orthogonality penalty with matrix operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a84498b2348321af4b371ea587be40