### PR TITLE
stream pretrained weights directly to device

### DIFF
--- a/experiments/phase1_teacher_extraction.py
+++ b/experiments/phase1_teacher_extraction.py
@@ -148,7 +148,11 @@ def extract_teacher_vectors(config, hierarchies, activations, exp_dir):
     logger.info("Extracting teacher vectors")
 
     # Use a model with an LM head so we can reliably find the unembedding & logits
-    model = AutoModelForCausalLM.from_pretrained(config["model"]["name"])
+    model = AutoModelForCausalLM.from_pretrained(
+        config["model"]["name"],
+        low_cpu_mem_usage=True,
+        device_map={"": config["run"]["device"]},
+    )
 
     # Prefer the model's lm_head when present
     if hasattr(model, "lm_head") and isinstance(model.lm_head, torch.nn.Linear):
@@ -250,7 +254,11 @@ def validate_geometry(config, parent_vectors, child_deltas, geometry, exp_dir):
     # Try alternative geometry sources if enabled
     try:
         # Load model for alternative geometries
-        model = AutoModelForCausalLM.from_pretrained(config["model"]["name"])
+        model = AutoModelForCausalLM.from_pretrained(
+            config["model"]["name"],
+            low_cpu_mem_usage=True,
+            device_map={"": config["run"]["device"]},
+        )
         tokenizer = AutoTokenizer.from_pretrained(config["model"]["name"])
         
         # Create dummy prompts for geometry validation
@@ -353,7 +361,11 @@ def validate_geometry(config, parent_vectors, child_deltas, geometry, exp_dir):
 
     # Run control experiments
     # Load unembedding matrix again for controls
-    control_model = AutoModelForCausalLM.from_pretrained(config["model"]["name"])
+    control_model = AutoModelForCausalLM.from_pretrained(
+        config["model"]["name"],
+        low_cpu_mem_usage=True,
+        device_map={"": config["run"]["device"]},
+    )
     if hasattr(control_model, "lm_head") and isinstance(
         control_model.lm_head, torch.nn.Linear
     ):

--- a/polytope_hsae/activations.py
+++ b/polytope_hsae/activations.py
@@ -68,14 +68,18 @@ class ActivationCapture:
                 config.model_name,
                 config=self.hf_config,
                 torch_dtype=config.dtype,
-            ).to(self.device)
+                low_cpu_mem_usage=True,
+                device_map={"": config.device},
+            )
         except Exception:
             from transformers import AutoModel
             self.model = AutoModel.from_pretrained(
                 config.model_name,
                 config=self.hf_config,
                 torch_dtype=config.dtype,
-            ).to(self.device)
+                low_cpu_mem_usage=True,
+                device_map={"": config.device},
+            )
             
         self.tokenizer = AutoTokenizer.from_pretrained(config.model_name)
 


### PR DESCRIPTION
## Summary
- load transformers models with `low_cpu_mem_usage=True` and explicit `device_map` to avoid duplicating weights in CPU
- update teacher extraction script to use same streaming approach across model loads

## Testing
- `pytest`
- `PYTHONPATH=. python experiments/phase1_teacher_extraction.py --config configs/v2-focused.yaml --dry-run --device cpu` *(fails: process killed, likely due to memory limits in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a897db52b48321bbfd7be3e5d1d206