### PR TITLE
persist geometry across phases

### DIFF
--- a/experiments/phase1_teacher_extraction.py
+++ b/experiments/phase1_teacher_extraction.py
@@ -152,6 +152,10 @@ def extract_teacher_vectors(config, hierarchies, activations, exp_dir, unembeddi
     geometry = CausalGeometry.from_unembedding(
         unembedding_matrix, shrinkage=config["geometry"]["shrinkage"]
     )
+    # Save precomputed geometry for later phases
+    geometry_file = exp_dir / "geometry.pt"
+    geometry.save(geometry_file)
+    logger.info(f"Saved geometry to {geometry_file}")
 
     # Create LDA estimator
     lda_estimator = LDAEstimator(

--- a/experiments/phase4_evaluation.py
+++ b/experiments/phase4_evaluation.py
@@ -619,23 +619,13 @@ def run_ratio_invariance_tests(parent_vectors, child_deltas, causal_geometry, co
 def run_euclidean_vs_causal_ablation(parent_vectors, child_deltas, config, exp_dir):
     """Run ablation comparing Euclidean vs causal geometry."""
     logger.info("Running Euclidean vs Causal ablation")
-
+    phase1_dir = Path(config["logging"]["save_dir"]) / config["logging"]["phase_1_log"]
+    geometry_file = phase1_dir / "geometry.pt"
     try:
-        from transformers import AutoModelForCausalLM
-
-        model = AutoModelForCausalLM.from_pretrained(config["model"]["name"])
-        if hasattr(model, "lm_head"):
-            unembedding_matrix = model.lm_head.weight.data
-        else:
-            unembedding_matrix = model.get_output_embeddings().weight.data
+        causal_geometry = CausalGeometry.load(str(geometry_file))
     except Exception as e:
-        logger.error(f"Could not load model for geometry ablation: {e}")
+        logger.error(f"Could not load geometry for ablation: {e}")
         return {}
-
-    # Causal geometry
-    causal_geometry = CausalGeometry(
-        unembedding_matrix, shrinkage=config["geometry"]["shrinkage"]
-    )
 
     # Compare angles in both geometries
     euclidean_angles = []


### PR DESCRIPTION
## Summary
- allow `CausalGeometry` to be saved and loaded
- phase 1 writes geometry.pt after computing unembedding geometry
- phases 3 and 4 reuse this cached geometry instead of reloading the transformer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a89d59dab483219e0df64399668818