### PR TITLE
Normalize vectors in causal space and improve triangulation controls

### DIFF
--- a/polytope_hsae/geometry.py
+++ b/polytope_hsae/geometry.py
@@ -271,6 +271,15 @@ class CausalGeometry:
         norm = self.causal_norm(x)
         return x / (norm + 1e-8)
 
+    def unit_c(self, x: torch.Tensor) -> torch.Tensor:
+        """Whiten ``x`` and return unit vector in causal space."""
+        w = self.whiten(x)
+        if w.ndim == 1:
+            denom = torch.linalg.norm(w) + 1e-8
+        else:
+            denom = torch.linalg.norm(w, dim=-1, keepdim=True) + 1e-8
+        return w / denom
+
     def random_rotate(self, x: torch.Tensor, angle_deg: float) -> torch.Tensor:
         """Rotate ``x`` by a given angle in a random causal-orthogonal direction."""
         angle = angle_deg * torch.pi / 180.0

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -3,8 +3,12 @@ import sys
 
 import torch
 
-from polytope_hsae.estimators import (LDAEstimator, OrthogonalityStats,
-                                      validate_orthogonality)
+from polytope_hsae.estimators import (
+    LDAEstimator,
+    OrthogonalityStats,
+    validate_orthogonality,
+    ConceptVectorEstimator,
+)
 from polytope_hsae.geometry import CausalGeometry
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -42,3 +46,39 @@ def test_validate_orthogonality_detects_orthogonal_and_nonorthogonal():
     stats_non = validate_orthogonality(parent_vectors, child_non, geom)
     assert stats_non.fraction_orthogonal_80deg == 0.0
     assert stats_non.mean_inner_product > 0.1
+
+
+def test_child_delta_uses_raw_vectors():
+    """Child deltas should be computed from unnormalized vectors."""
+
+    class DummyLDA:
+        def estimate_binary_direction(self, X_pos, X_neg, geometry, normalize=True):
+            # Return a known raw vector depending on inputs
+            if torch.allclose(X_pos, torch.tensor([[1.0, 0.0]])):
+                vec = torch.tensor([2.0, 0.0])  # parent vector (length 2)
+            else:
+                vec = torch.tensor([0.0, 3.0])  # child vector (length 3)
+            if normalize:
+                return geometry.normalize_causal(vec)
+            return vec
+
+    geom = CausalGeometry(torch.eye(2))
+    estimator = ConceptVectorEstimator(lda_estimator=DummyLDA(), geometry=geom)
+
+    parent_activations = {
+        "p": {"pos": torch.tensor([[1.0, 0.0]]), "neg": torch.zeros(1, 2)}
+    }
+    child_activations = {
+        "p": {"c": {"pos": torch.tensor([[0.0, 1.0]]), "neg": torch.zeros(1, 2)}}
+    }
+
+    parent_vectors = estimator.estimate_parent_vectors(parent_activations)
+    child_deltas = estimator.estimate_child_deltas(parent_vectors, child_activations)
+    delta = child_deltas["p"]["c"]
+
+    parent_wh = geom.unit_c(torch.tensor([2.0, 0.0]))
+    child_wh = geom.unit_c(torch.tensor([0.0, 3.0]))
+    delta_wh = child_wh - parent_wh
+    delta_wh = delta_wh / torch.linalg.norm(delta_wh)
+    expected = geom.unwhiten(delta_wh)
+    assert torch.allclose(delta, expected)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,7 +20,10 @@ def test_hierarchical_orthogonality_returns_dataframe():
         "parent_id",
         "child_id",
         "angle_deg",
-        "inner_product",
+        "cosine",
+        "parent_norm",
+        "child_norm",
+        "delta_norm",
     }
     assert len(results["details"]) == 1
 


### PR DESCRIPTION
## Summary
- Compute parent and child directions in whitened causal space and normalize deltas before angle checks
- Log causal cosines, vector norms, and top eigenvalues; expand controls with sibling-swap and Euclidean metric ablations
- Integrate residual-activation geometry for triangulation and forward raw vectors to control experiments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8aadd82a08321995af20507167905