### PR TITLE
Normalize causal geometry and expand geometry controls

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,16 +11,21 @@ def test_hierarchical_orthogonality_returns_dataframe():
     geometry = CausalGeometry(U)
     validator = GeometryValidator(geometry)
 
-    parent_vectors = {"p": torch.tensor([1.0, 0.0, 0.0, 0.0])}
-    child_deltas = {"p": {"c": torch.tensor([0.0, 1.0, 0.0, 0.0])}}
+    parent_vectors = {"p": geometry.normalize_causal(torch.tensor([1.0, 0.0, 0.0, 0.0]))}
+    child_vectors = {"p": {"c": geometry.normalize_causal(torch.tensor([0.0, 1.0, 0.0, 0.0]))}}
+    delta = geometry.normalize_causal(child_vectors["p"]["c"] - parent_vectors["p"])
+    child_deltas = {"p": {"c": delta}}
 
-    results = validator.test_hierarchical_orthogonality(parent_vectors, child_deltas)
+    results = validator.test_hierarchical_orthogonality(parent_vectors, child_vectors, child_deltas)
     assert isinstance(results["details"], pd.DataFrame)
     assert set(results["details"].columns) == {
         "parent_id",
         "child_id",
         "angle_deg",
-        "inner_product",
+        "cosine",
+        "parent_norm",
+        "child_norm",
+        "delta_norm",
     }
     assert len(results["details"]) == 1
 


### PR DESCRIPTION
## Summary
- Normalize parent, child, and delta vectors in causal space and return both child vectors and deltas
- Log causal cosines, vector norms, and top Σ eigenvalues for orthogonality tests
- Replace shuffled control with sibling-swap and Euclidean-metric ablations; add activations-based geometry and triangulation spread check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8bf5b00cc8321be4fa0122052b0db